### PR TITLE
Binary and cereal instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to the
 
 ## Unreleased
 
+## 0.1.1.0 - 2025-02-05
+
+- Add serialization support of `Vary` for `binary`'s `Data.Binary` and `cereal`'s `Data.Serialize`.
+- Document `Data.Aeson` round-tripping behaviour (namely: only round-trippable if encodings do not overlap, the `UntaggedValue` sum encoding).
+
 ## 0.1.0.5 - 2025-02-05
 
 - Relax max allowed versions of DeepSeq (<1.6), Hashable (<1.6), QuickCheck (<2.16)

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ The following is executed by the README test runner,
 but we don't want it to be visible to human readers:
 
 ```haskell top:1
+{-# OPTIONS_GHC -Wno-missing-export-lists #-}
 {-# OPTIONS_GHC -fdefer-type-errors #-} -- We want to show some incorrect examples!
 module Main where
 

--- a/package.yaml
+++ b/package.yaml
@@ -70,11 +70,11 @@ when:
     cpp-options: -DFLAG_AESON
   - condition: flag(binary)
     dependencies:
-    - binary
+    - binary >= 0.8.0.0 && < 0.9.0.0
     cpp-options: -DFLAG_BINARY
   - condition: flag(binary)
     dependencies:
-    - cereal
+    - cereal >= 0.5.0.0 && < 0.6.0.0
     cpp-options: -DFLAG_CEREAL
   - condition: flag(quickcheck)
     dependencies:

--- a/package.yaml
+++ b/package.yaml
@@ -118,6 +118,12 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - vary
+    - hspec
+    - QuickCheck >= 2.12 && < 2.15
+    - aeson >= 2.0.0 && < 2.3
+    - binary
+    - bytestring
+    - cereal
   doctests:
     main: doctests.hs
     source-dirs: test/doctest

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,10 @@ flags:
     description: "When enabled implements the @FromJSON@/@ToJSON@ typeclasses from the aeson library. When disabled, does not depend on the aeson library."
     default: true
     manual: true
+  cereal:
+    description: "When enabled implements the @Serialize@ typeclass from the cereal library. When disabled, does not depend on the cereal library."
+    default: true
+    manual: true
   hashable:
     description: "When enabled implements the @Hashable@ typeclass from the hashable library. When disabled, does not depend on the @hashable@ library."
     default: true
@@ -60,6 +64,10 @@ when:
     dependencies:
     - aeson >= 2.0.0 && < 2.3
     cpp-options: -DFLAG_AESON
+  - condition: flag(cereal)
+    dependencies:
+    - cereal
+    cpp-options: -DFLAG_CEREAL
   - condition: flag(quickcheck)
     dependencies:
     - QuickCheck >= 2.12 && < 2.15

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,10 @@ flags:
     description: "When enabled implements the @FromJSON@/@ToJSON@ typeclasses from the aeson library. When disabled, does not depend on the aeson library."
     default: true
     manual: true
+  binary:
+    description: "When enabled implements the @Binary@ typeclass from the binary library. When disabled, does not depend on the binary library."
+    default: true
+    manual: true
   cereal:
     description: "When enabled implements the @Serialize@ typeclass from the cereal library. When disabled, does not depend on the cereal library."
     default: true
@@ -64,7 +68,11 @@ when:
     dependencies:
     - aeson >= 2.0.0 && < 2.3
     cpp-options: -DFLAG_AESON
-  - condition: flag(cereal)
+  - condition: flag(binary)
+    dependencies:
+    - binary
+    cpp-options: -DFLAG_BINARY
+  - condition: flag(binary)
     dependencies:
     - cereal
     cpp-options: -DFLAG_CEREAL

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                vary
-version:             0.1.0.5
+version:             0.1.1.0
 github:              "qqwy/haskell-vary"
 license:             MIT
 author:              "Marten Wijnja (Qqwy)"

--- a/src/Vary.hs
+++ b/src/Vary.hs
@@ -27,6 +27,7 @@ module Vary
     -- $setup
     -- $motivating_example
     -- $vary_and_exceptions
+    -- $vary_and_serialization
 
     -- * Core type definition
     Vary,
@@ -62,6 +63,7 @@ import GHC.TypeLits
 import Unsafe.Coerce (unsafeCoerce)
 import Vary.Core (Vary (..))
 import Vary.Utils
+import qualified Vary as encoding
 
 -- $setup
 --
@@ -149,6 +151,19 @@ A longer example on why you would want to use Vary [can be found in the package 
 -- >>> catcher (throw AllocationLimitExceeded)
 -- *** Exception: allocation limit exceeded
 
+
+-- $vary_and_serialization
+--
+-- == (De)Serializing Vary values
+--
+-- `Vary` has optional dependencies to enable `aeson`'s `Data.Aeson`, `binary`'s `Data.Binary` and `cereal`'s `Data.Serealize` serialization.
+--
+-- Specifically for Aeson serialization, Vary datatypes are encoded
+-- as their ['UntaggedValue'](https://hackage.haskell.org/package/aeson-2.0.3.0/docs/Data-Aeson-Types.html#t:SumEncoding) encoding.
+-- This means that serialization to JSON only round-trips when the encodings are disjoint;
+-- on decoding, the first variant to succeed is used.
+--
+-- The Binary and Serialize instances always round-trip, as their encoding contains the variant's tag index.
 
 -- | Builds a Vary from the given value.
 --

--- a/src/Vary/Core.hs
+++ b/src/Vary/Core.hs
@@ -240,6 +240,10 @@ deriving instance Aeson.FromJSON (Vary '[])
 
 deriving instance (Aeson.FromJSON a) => Aeson.FromJSON (Vary '[a])
 
+-- | This instance round-trips iff there is no overlap between the encodings of the element types.
+--
+-- For example, a `Vary '[Int, String] is round-trippable
+-- but a `Vary '[String, Char]` is not.
 instance (Aeson.FromJSON a, Aeson.FromJSON (Vary (b : bs))) => Aeson.FromJSON (Vary (a : b : bs)) where
   {-# INLINE parseJSON #-}
   parseJSON val = (pushHead <$> Aeson.parseJSON val) <|> (pushTail <$> Aeson.parseJSON val)
@@ -248,6 +252,10 @@ deriving instance Aeson.ToJSON (Vary '[])
 
 deriving instance (Aeson.ToJSON a) => Aeson.ToJSON (Vary '[a])
 
+-- | This instance round-trips iff there is no overlap between the encodings of the element types.
+--
+-- For example, a `Vary '[Int, String] is round-trippable
+-- but a `Vary '[String, Char]` is not.
 instance (Aeson.ToJSON a, Aeson.ToJSON (Vary (b : bs))) => Aeson.ToJSON (Vary (a : b : bs)) where
   {-# INLINE toJSON #-}
   toJSON vary =

--- a/src/Vary/VEither.hs
+++ b/src/Vary/VEither.hs
@@ -62,6 +62,10 @@ import Data.Hashable
 import Test.QuickCheck
 # endif
 
+# ifdef FLAG_CEREAL
+import Data.Serialize qualified as Cereal
+# endif
+
 -- $setup
 --
 -- This module is intended to be used qualified:
@@ -353,4 +357,8 @@ deriving instance Aeson.FromJSON (Vary (a : errs)) => Aeson.FromJSON (VEither er
 
 #ifdef FLAG_QUICKCHECK
 deriving instance (Arbitrary (Vary (a : errs))) => Test.QuickCheck.Arbitrary (VEither errs a)
+#endif
+
+#ifdef FLAG_CEREAL
+deriving instance (Cereal.Serialize (Vary (a : errs))) => Cereal.Serialize (VEither errs a)
 #endif

--- a/src/Vary/VEither.hs
+++ b/src/Vary/VEither.hs
@@ -66,6 +66,10 @@ import Test.QuickCheck
 import Data.Serialize qualified as Cereal
 # endif
 
+# ifdef FLAG_BINARY
+import Data.Binary qualified as Binary
+# endif
+
 -- $setup
 --
 -- This module is intended to be used qualified:
@@ -361,4 +365,8 @@ deriving instance (Arbitrary (Vary (a : errs))) => Test.QuickCheck.Arbitrary (VE
 
 #ifdef FLAG_CEREAL
 deriving instance (Cereal.Serialize (Vary (a : errs))) => Cereal.Serialize (VEither errs a)
+#endif
+
+#ifdef FLAG_BINARY
+deriving instance (Binary.Binary (Vary (a : errs))) => Binary.Binary (VEither errs a)
 #endif

--- a/test/doctest/doctests.hs
+++ b/test/doctest/doctests.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-missing-export-lists #-}
 module Main where
 
 import Test.DocTest (mainFromCabal)

--- a/test/spec/spec.hs
+++ b/test/spec/spec.hs
@@ -15,7 +15,7 @@ import Data.Serialize qualified as Cereal
 
 import Vary (Vary)
 
-type TestVariant = Vary '[Int, Double, Char, String]
+type TestVariant = Vary '[Int, String, Maybe [Bool]]
 
 main :: IO ()
 main = hspec $ do
@@ -23,6 +23,8 @@ main = hspec $ do
     prop "encodes properly" $ \(v :: TestVariant) -> do
       Aeson.encode v `shouldSatisfy` (not . LBS.null)
     prop "encode - decode roundtrips" $ \(v :: TestVariant) -> do
+      -- NOTE: `TestVariant` is chosen so the JSON encodings do not overlap.
+      -- Without that, this property would not hold
       Aeson.eitherDecode (Aeson.encode v) `shouldBe` Right v
 
   describe "Serialization with binary" $ do

--- a/test/spec/spec.hs
+++ b/test/spec/spec.hs
@@ -1,3 +1,38 @@
-module Main where
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main (main) where
+
+import Test.Hspec
+import Test.Hspec.QuickCheck
+
+import Data.Aeson qualified as Aeson
+import Data.Binary qualified as Binary
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.Serialize qualified as Cereal
+
+import Vary (Vary)
+
+type TestVariant = Vary '[Int, Double, Char, String]
+
 main :: IO ()
-main = putStrLn "(No separate unit tests yet)"
+main = hspec $ do
+  describe "Serialization with aeson" $ do
+    prop "encodes properly" $ \(v :: TestVariant) -> do
+      Aeson.encode v `shouldSatisfy` (not . LBS.null)
+    prop "encode - decode roundtrips" $ \(v :: TestVariant) -> do
+      Aeson.eitherDecode (Aeson.encode v) `shouldBe` Right v
+
+  describe "Serialization with binary" $ do
+    prop "encodes properly" $ \(v :: TestVariant) -> do
+      Binary.encode v `shouldSatisfy` (not . LBS.null)
+    prop "encode - decode roundtrips" $ \(v :: TestVariant) -> do
+      Binary.decode (Binary.encode v) `shouldBe` v
+
+  describe "Serialization with cereal" $ do
+    prop "encodes properly" $ \(v :: TestVariant) -> do
+      Cereal.encode v `shouldSatisfy` (not . BS.null)
+    prop "encode - decode roundtrips" $ \(v :: TestVariant) -> do
+      Cereal.decode (Cereal.encode v) `shouldBe` Right v

--- a/vary.cabal
+++ b/vary.cabal
@@ -176,8 +176,14 @@ test-suite vary-test
       test/spec
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      QuickCheck >=2.12 && <2.15
+    , aeson >=2.0.0 && <2.3
+    , base >=4.7 && <5
+    , binary
+    , bytestring
+    , cereal
     , deepseq >=1.4.0 && <1.5
+    , hspec
     , vary
   default-language: Haskell2010
   if flag(hashable)

--- a/vary.cabal
+++ b/vary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -40,6 +40,11 @@ flag aeson
   manual: True
   default: True
 
+flag cereal
+  description: When enabled implements the @Serialize@ typeclass from the cereal library. When disabled, does not depend on the cereal library.
+  manual: True
+  default: True
+
 flag hashable
   description: When enabled implements the @Hashable@ typeclass from the hashable library. When disabled, does not depend on the @hashable@ library.
   manual: True
@@ -72,6 +77,10 @@ library
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
+  if flag(cereal)
+    cpp-options: -DFLAG_CEREAL
+    build-depends:
+        cereal
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:
@@ -99,6 +108,10 @@ test-suite doctests
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
+  if flag(cereal)
+    cpp-options: -DFLAG_CEREAL
+    build-depends:
+        cereal
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:
@@ -128,6 +141,10 @@ test-suite readme
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
+  if flag(cereal)
+    cpp-options: -DFLAG_CEREAL
+    build-depends:
+        cereal
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:
@@ -154,6 +171,10 @@ test-suite vary-test
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
+  if flag(cereal)
+    cpp-options: -DFLAG_CEREAL
+    build-depends:
+        cereal
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:

--- a/vary.cabal
+++ b/vary.cabal
@@ -40,6 +40,11 @@ flag aeson
   manual: True
   default: True
 
+flag binary
+  description: When enabled implements the @Binary@ typeclass from the binary library. When disabled, does not depend on the binary library.
+  manual: True
+  default: True
+
 flag cereal
   description: When enabled implements the @Serialize@ typeclass from the cereal library. When disabled, does not depend on the cereal library.
   manual: True
@@ -77,7 +82,11 @@ library
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
-  if flag(cereal)
+  if flag(binary)
+    cpp-options: -DFLAG_BINARY
+    build-depends:
+        binary
+  if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
         cereal
@@ -108,7 +117,11 @@ test-suite doctests
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
-  if flag(cereal)
+  if flag(binary)
+    cpp-options: -DFLAG_BINARY
+    build-depends:
+        binary
+  if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
         cereal
@@ -141,7 +154,11 @@ test-suite readme
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
-  if flag(cereal)
+  if flag(binary)
+    cpp-options: -DFLAG_BINARY
+    build-depends:
+        binary
+  if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
         cereal
@@ -171,7 +188,11 @@ test-suite vary-test
     cpp-options: -DFLAG_AESON
     build-depends:
         aeson >=2.0.0 && <2.3
-  if flag(cereal)
+  if flag(binary)
+    cpp-options: -DFLAG_BINARY
+    build-depends:
+        binary
+  if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
         cereal

--- a/vary.cabal
+++ b/vary.cabal
@@ -85,11 +85,11 @@ library
   if flag(binary)
     cpp-options: -DFLAG_BINARY
     build-depends:
-        binary
+        binary >=0.8.0.0 && <0.9.0.0
   if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
-        cereal
+        cereal >=0.5.0.0 && <0.6.0.0
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:
@@ -120,11 +120,11 @@ test-suite doctests
   if flag(binary)
     cpp-options: -DFLAG_BINARY
     build-depends:
-        binary
+        binary >=0.8.0.0 && <0.9.0.0
   if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
-        cereal
+        cereal >=0.5.0.0 && <0.6.0.0
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:
@@ -157,11 +157,11 @@ test-suite readme
   if flag(binary)
     cpp-options: -DFLAG_BINARY
     build-depends:
-        binary
+        binary >=0.8.0.0 && <0.9.0.0
   if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
-        cereal
+        cereal >=0.5.0.0 && <0.6.0.0
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:
@@ -197,11 +197,11 @@ test-suite vary-test
   if flag(binary)
     cpp-options: -DFLAG_BINARY
     build-depends:
-        binary
+        binary >=0.8.0.0 && <0.9.0.0
   if flag(binary)
     cpp-options: -DFLAG_CEREAL
     build-depends:
-        cereal
+        cereal >=0.5.0.0 && <0.6.0.0
   if flag(quickcheck)
     cpp-options: -DFLAG_QUICKCHECK
     build-depends:


### PR DESCRIPTION
Very cool library! I was playing around with serializing these variants as a learning exercise and thought that instances for `Binary` and `Serialize` from the binary and cereal packages could be useful for some people. I see that `Serialize` is mentioned in #3 as well, but not defined here yet. 

In testing that these all roundtrip, I noticed that the `FromJSON` and `ToJSON` instances don't satisfy this property if any of the types in the variant list have the same json encoding. For example, `Vary.from 'a' :: Vary '[Char, String]` and `Vary.from "a" :: Vary '[Char, String]` both encode as the json string "a", but when decoding, you always get the `Char` variant because it comes first in the list. This is the same behavior as `UntaggedValue` from the [aeson `SumEncoding` options](https://hackage.haskell.org/package/aeson-2.0.3.0/docs/Data-Aeson-Types.html#t:SumEncoding). If you do want round tripping, I can change the aeson instances to use tagged objects, or if you'd prefer to keep the current behavior, I'll delete the failing test and just leave a note on the instance.