### PR TITLE
Add support for `ghc-8.10.7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ import qualified Vary.VEither as VEither
 The library is intended to be used with the following extensions active:
 
 ```haskell top:0
-{-# LANGUAGE GHC2021 #-} -- Of these, Vary uses: TypeApplications, TypeOperators, FlexibleContexts
+{-# LANGUAGE FlexibleContexts #-}  -- As of ghc-9.2 can use GHC2021 instead
+{-# LANGUAGE TypeApplications #-}  -- As of ghc-9.2 can use GHC2021 instead
+{-# LANGUAGE TypeOperators #-}  -- As of ghc-9.2 can use GHC2021 instead
 {-# LANGUAGE DataKinds #-}
 ```
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE DataKinds #-}
 module Main (main) where
 

--- a/src/Vary.hs
+++ b/src/Vary.hs
@@ -80,8 +80,6 @@ import Vary.Utils
 -- 
 -- And for many functions, it is useful (and sometimes outright necessary) to enable the following extensions:
 --
--- >>> -- Of the GHC2021 set, Vary uses: TypeApplications, TypeOperators, FlexibleContexts:
--- >>> :set -XGHC2021 
 -- >>> :set -XDataKinds
 --
 -- Finally, some example snippets in this module make use of 'Data.Function.&', the left-to-right function application operator.

--- a/src/Vary/Core.hs
+++ b/src/Vary/Core.hs
@@ -1,9 +1,16 @@
-{-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
 module Vary.Core (Vary (..), pop) where
@@ -15,10 +22,10 @@ import Data.Kind (Type)
 import Data.Typeable (Typeable, typeOf)
 import GHC.Exts (Any)
 import GHC.Generics
-import Unsafe.Coerce qualified as Data.Coerce
+import qualified Unsafe.Coerce as Data.Coerce
 
 # ifdef FLAG_AESON
-import Data.Aeson qualified as Aeson
+import qualified Data.Aeson as Aeson
 # endif
 
 # ifdef FLAG_HASHABLE
@@ -31,15 +38,14 @@ import Test.QuickCheck.Arbitrary (GSubterms, RecursivelyShrink)
 # endif
 
 # ifdef FLAG_BINARY
-import Data.Binary qualified as Binary
+import qualified Data.Binary as Binary
 # endif
 
 # ifdef FLAG_CEREAL
-import Data.Serialize qualified as Cereal
+import qualified Data.Serialize as Cereal
 # endif
 
 -- $setup
--- >>> :set -XGHC2021
 -- >>> :set -XDataKinds
 -- >>> import Vary (Vary, (:|))
 -- >>> import qualified Vary

--- a/src/Vary/Utils.hs
+++ b/src/Vary/Utils.hs
@@ -1,11 +1,20 @@
-{-# LANGUAGE GHC2021 #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# HLINT ignore "Use camelCase" #-} -- <- We want a fun long type name with underscores for easier to read errors ;-)
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Vary.Utils(
     -- | 
     -- This module contains functions and typeclasses/type families (type-level functions)

--- a/src/Vary/VEither.hs
+++ b/src/Vary/VEither.hs
@@ -1,10 +1,18 @@
-{-# LANGUAGE GHC2021 #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
 module Vary.VEither (
   -- * General Usage
   -- $setup
@@ -51,7 +59,7 @@ import qualified Vary
 import GHC.Generics
 
 # ifdef FLAG_AESON
-import Data.Aeson qualified as Aeson
+import qualified Data.Aeson as Aeson
 # endif
 
 # ifdef FLAG_HASHABLE
@@ -63,11 +71,11 @@ import Test.QuickCheck
 # endif
 
 # ifdef FLAG_CEREAL
-import Data.Serialize qualified as Cereal
+import qualified Data.Serialize as Cereal
 # endif
 
 # ifdef FLAG_BINARY
-import Data.Binary qualified as Binary
+import qualified Data.Binary as Binary
 # endif
 
 -- $setup
@@ -79,7 +87,6 @@ import Data.Binary qualified as Binary
 -- 
 -- And for many functions, it is useful or outright necessary to enable the following extensions:
 --
--- >>> :set -XGHC2021
 -- >>> :set -XDataKinds
 --
 -- Finally, some example snippets in this module make use of 'Data.Function.&', the left-to-right function application operator.
@@ -148,14 +155,18 @@ veither _ g (VRight y)    =  g y
 
 -- Matches when the VEither contains one of the errors, returning @Vary errs@
 pattern VLeft :: forall a errs. Vary errs -> VEither errs a
+#if __GLASGOW_HASKELL__ >= 902
 {-# INLINE VLeft #-}
+#endif
 pattern VLeft errs <- (toEither -> Left errs)
    where
       VLeft (Vary tag err) = VEither ((Vary (tag+1) err))
 
 -- | Matches when the VEither contains the preferred value of type @a@.
 pattern VRight :: forall a errs. a -> VEither errs a
+#if __GLASGOW_HASKELL__ >= 902
 {-# INLINE VRight #-}
+#endif
 pattern VRight a <- (toEither -> Right a)
   where
     VRight a = VEither (Vary.from @a a)


### PR DESCRIPTION
This is done by not using `GHC2021` in the source code but using the required underlying language extensions directly.

Users of the library may still use `GHC2021`.