### PR TITLE
[feat] add VS, VZ and VEmpty pattern synonyms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 *~
+dist*


### PR DESCRIPTION
Let me know what you think of this - this mirrors the behaviour of `NS` from `sop-core`. There's more pattern synonyms that might be useful, e.g. 

`Vary @t t -> ...` akin to this: 

```haskell
pattern TypeIs :: forall b. Typeable b => forall a. a ~ b => a -> Dynamic
pattern TypeIs x <- (fromDynamic -> Just x)
  where
    TypeIs a = toDyn a

y :: Dynamic -> Int
y = \case
  TypeIs @Int a -> a
  TypeIs @Bool True -> 2
  TypeIs @(Maybe Char) (Just c) -> ord c
  TypeIs @(Maybe Char) Nothing -> 9
  _ -> 0
```