### PR TITLE
Qqwy/support ghc 8.10.7

### DIFF
--- a/.github/workflows/flag_builds.yaml
+++ b/.github/workflows/flag_builds.yaml
@@ -5,6 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        ghc-version: ['9.6.3', '8.10.7']
         flags: [
           "",
           "--flag=vary:-aeson",
@@ -21,7 +22,7 @@ jobs:
           path: |
             ~/.stack
             .stack-work
-          key: ${{ runner.os }}-stack-withflags-${{ matrix.flags }}-${{ hashFiles('stack.yaml.lock', 'package.yaml') }}
+          key: ${{ runner.os }}-stack-${{ matrix.ghc-version }}-withflags-${{ matrix.flags }}-${{ hashFiles('stack.yaml.lock', 'package.yaml') }}
           restore-keys: |
             ${{ runner.os }}-stack-
       - name: Restore cached dependencies
@@ -29,12 +30,11 @@ jobs:
         id: cache
         with:
             path: ~/.stack
-            key: ${{ runner.os }}-stack-withflags-${{ matrix.flags }}-${{ hashFiles('**/*.cabal') }}
+            key: ${{ runner.os }}-stack-${{ matrix.ghc-version }}-withflags-${{ matrix.flags }}-${{ hashFiles('**/*.cabal') }}
       - uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.6.3' # Exact version of ghc to use
+          ghc-version: ${{ matrix.ghc-version }} # Exact version of ghc to use
           # cabal-version: 'latest'. Omitted, but defaults to 'latest'
           enable-stack: true
           stack-version: 'latest'
       - run: stack build --ghc-options=-Wall ${{ matrix.flags }}
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to the
 
 ## Unreleased
 
+## 0.1.1.2 - 2025-04-16
+
+- Lower the minimum supported GHC version to v8.10.x by removing internal usage of `GHC2021`. ([PR #9](https://github.com/Qqwy/haskell-vary/pull/9)) Thank you, @newhoggy and @carbolymer!
+
 ## 0.1.1.1 - 2025-02-06
 
 - Loosen test dependency bound on QuickCheck.

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ import qualified Vary.VEither as VEither
 The library is intended to be used with the following extensions active:
 
 ```haskell top:0
-{-# LANGUAGE FlexibleContexts #-}  -- As of ghc-9.2 can use GHC2021 instead
-{-# LANGUAGE TypeApplications #-}  -- As of ghc-9.2 can use GHC2021 instead
-{-# LANGUAGE TypeOperators #-}  -- As of ghc-9.2 can use GHC2021 instead
 {-# LANGUAGE DataKinds #-}
+-- As of GHC >= 9.2, you can replace the following three extensions by GHC2021 instead:
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 ```
 
 ### Simple usage

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                vary
-version:             0.1.1.1
+version:             0.1.1.2
 github:              "qqwy/haskell-vary"
 license:             MIT
 author:              "Marten Wijnja (Qqwy)"

--- a/src/Vary.hs
+++ b/src/Vary.hs
@@ -81,6 +81,10 @@ import Vary.Utils
 -- And for many functions, it is useful (and sometimes outright necessary) to enable the following extensions:
 --
 -- >>> :set -XDataKinds
+-- >>> -- As of GHC >= 9.2, you can replace the following three extensions by GHC2021 instead:
+-- >>> {-# LANGUAGE FlexibleContexts #-}
+-- >>> {-# LANGUAGE TypeApplications #-}
+-- >>> {-# LANGUAGE TypeOperators #-}
 --
 -- Finally, some example snippets in this module make use of 'Data.Function.&', the left-to-right function application operator.
 --

--- a/src/Vary/Core.hs
+++ b/src/Vary/Core.hs
@@ -10,6 +10,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_HADDOCK not-home #-}
 

--- a/src/Vary/VEither.hs
+++ b/src/Vary/VEither.hs
@@ -88,6 +88,10 @@ import qualified Data.Binary as Binary
 -- And for many functions, it is useful or outright necessary to enable the following extensions:
 --
 -- >>> :set -XDataKinds
+-- >>> -- As of GHC >= 9.2, you can replace the following three extensions by GHC2021 instead:
+-- >>> {-# LANGUAGE FlexibleContexts #-}
+-- >>> {-# LANGUAGE TypeApplications #-}
+-- >>> {-# LANGUAGE TypeOperators #-}
 --
 -- Finally, some example snippets in this module make use of 'Data.Function.&', the left-to-right function application operator.
 --

--- a/vary.cabal
+++ b/vary.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           vary
-version:        0.1.1.0
+version:        0.1.1.1
 synopsis:       Vary: Friendly and fast polymorphic variants (open unions/coproducts/extensible sums)
 description:    Vary: Friendly and fast Variant types for Haskell
                 .
@@ -176,7 +176,7 @@ test-suite vary-test
       test/spec
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck >=2.12 && <2.15
+      QuickCheck >=2.12 && <2.16
     , aeson >=2.0.0 && <2.3
     , base >=4.7 && <5
     , binary


### PR DESCRIPTION
Tiny follow-up PR of #9 

- [x] Make sure `Vary.Core` has all necessary language extensions enabled to compile without `GHC2021`
- [x] Clarify usage of extensions in the moduledoc of the two modules and README.
- [x] Add 'does it build with  of GHC 8.10.x' to the CI workflow. 
- [x] Fill in Changelog
- [x] bump version in `package.yaml`